### PR TITLE
Fill GraphQL API for WP

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The differences in how GraphQL implementations interpret and conform to the Grap
 
 <tr>
     <td><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/graphql-api-for-wp.md">graphql-api-for-wp</a></td>
-    <td align="center"><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/graphql-api-for-wp.md#Request-Validations">36</a></td>
+    <td align="center"><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/graphql-api-for-wp.md#Request-Validations">37</a></td>
     <td align="center">⚠️</td>
     <td align="center">❌</td>
     <td align="center">❌</td>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ The differences in how GraphQL implementations interpret and conform to the Grap
 </tr>
 
 <tr>
+    <td><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/graphql-api-for-wp.md">graphql-api-for-wp</a></td>
+    <td align="center"><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/graphql-api-for-wp.md#Request-Validations">36</a></td>
+    <td align="center">⚠️</td>
+    <td align="center">❌</td>
+    <td align="center">❌</td>
+    <td align="center">✅</td>
+    <td align="center">✅</td>
+    <td align="center">⚠️</td>
+    <td align="center">✅</td>
+</tr>
+
+<tr>
     <td><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/apollo.md">Apollo</a></td>
     <td align="center"><a href="https://github.com/nicholasaleks/graphql-threat-matrix/blob/master/implementations/apollo.md#Request-Validations">34</a></td>
     <td align="center">✅</td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -61,7 +61,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L111">Fragments On Composite Types</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php#L414">Known Type Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L248">Known Directives</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">No Undefined Variables</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L383">No Undefined Variables</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
     </tr>
     <tr>
@@ -90,11 +90,11 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Unique Argument Names</a></td>
-        <td><a href="">No Unused Fragments</a></td>
-        <td><a href="">Unique Operation Types</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L667">Unique Argument Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L312">No Unused Fragments</a></td>
+        <td><a href="">Unique Type Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
         <td><a href=""></a></td>
-        <td><a href="">Variables Are Input Types</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">Variables In Allowed Position</a></td>
         <td><a href=""></a></td>
     </tr>
     <tr>
@@ -103,9 +103,9 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="">Provided Required Arguments On Directives</a></td>
         <td><a href="">Possible Fragment Spreads</a></td>
-        <td><a href="">Unique Type Names</a></td>
+        <td><a href="">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
-        <td><a href="">Variables In Allowed Position</a></td>
+        <td><a href=""></a></td>
         <td><a href=""></a></td>
     </tr>
     <tr>
@@ -114,7 +114,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="">Unique Fragment Names</a></td>
-        <td><a href="">Values Of Correct Type</a></td>
+        <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -79,11 +79,11 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Provided Required Arguments</a></td>
-        <td><a href="">No Fragment Cycles</a></td>
-        <td><a href="">Unique Enum Value Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L276">No Fragment Cycles</a></td>
+        <td><a href="">Unique Enum Value Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
         <td><a href=""></a></td>
-        <td><a href="">Unique Variable Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L357">Unique Variable Names</a></td>
         <td><a href=""></a></td>
     </tr>
     <tr>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -106,7 +106,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77"></a>Field Is Not Relational Type (Can't Nest Data)</td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -117,7 +117,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L178">No Field Or Directive Was Found With Required Version Constraint</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -55,7 +55,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     </tr>
     <tr>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a> <= This is implicit, because the server is code-first: it doesn't handle SDL, hence non-executable definitions are directly not supported, and the parser will already throw an error</td>
-        <td><a href="">Lone Anonymous Operation</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L87">Lone Anonymous Operation</a></td>
         <td><a href="">Fields on Correct Type</a></td>
         <td><a href="">Known Argument Names</a></td>
         <td><a href="">Fragments On Composite Types</a></td>
@@ -66,7 +66,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     </tr>
     <tr>
         <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>
-        <td><a href="">Unique Operation Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L128">Unique Operation Names</a></td>
         <td><a href="">Overlapping Fields Can Be Merged</a></td>
         <td><a href="">Known Argument Names On Directives</a></td>
         <td><a href="">Known Fragment Names</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -1,4 +1,4 @@
-# GraphQL API for Wordpress
+# GraphQL API for WordPress
 
 ### Table of Contents
 * [About](#About)
@@ -13,7 +13,7 @@ Source: [https://github.com/leoloso/PoP](https://github.com/leoloso/PoP)\
 Documentation: [https://graphql-api.com/](https://graphql-api.com/)
 
 ## Security Considerations
-GraphQL API for Wordpress provides the following features which should be taken into consideration:
+GraphQL API for WordPress provides the following features which should be taken into consideration:
 
 <table>
     <tr>
@@ -39,7 +39,7 @@ GraphQL API for Wordpress provides the following features which should be taken 
 ## Request Validations
 Total Validation Count: **36**
 
-GraphQL API for Wordpress validates the following checks when a query is sent:
+GraphQL API for WordPress validates the following checks when a query is sent:
 
 <table>
     <tr>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -100,21 +100,10 @@ GraphQL API for WordPress validates the following checks when a query is sent:
     <tr>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L112">Operation Provided In Document</a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Leaf Field Selections</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L93">Possible Fragment Spreads</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Field Is Not Relational Type (Can't Nest Data)</a></td>
-    </tr>
-    <tr>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a> <a href="https://github.com/graphql/graphql-spec/pull/825">(Spec RFC Stage 2)</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L178">No Field Or Directive Was Found With Required Version Constraint</a></td>
@@ -123,9 +112,9 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a> <a href="https://github.com/graphql/graphql-spec/pull/825">(Spec RFC Stage 2)</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php#L95">A Directive's Behavior Can Be Modified By At Most 1 Other Directive</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -37,7 +37,7 @@ GraphQL API for WordPress provides the following features which should be taken 
 </table>
 
 ## Request Validations
-Total Validation Count: **36**
+Total Validation Count: **37**
 
 GraphQL API for WordPress validates the following checks when a query is sent:
 
@@ -62,7 +62,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php#L414">Known Type Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L248">Known Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L383">No Undefined Variables</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/b3a25ca4c07578aaf4fe0a9cb3e0057593a85e5a/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/modules/single-endpoint.md">Disable Single Endpoint, Obfuscate Endpoint Path</a></td>
     </tr>
     <tr>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">(Lone Schema Definition)</a></td>
@@ -73,7 +73,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">(Possible Type Extensions)</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L429">Repeatable Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -84,7 +84,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L262">Unique Enum Value Names</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L357">Unique Variable Names</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -95,7 +95,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">Variables In Allowed Position</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -106,7 +106,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Field Is Not Relational Type (Can't Nest Data)</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -115,6 +115,17 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Field Is Not Relational Type (Can't Nest Data)</a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L178">No Field Or Directive Was Found With Required Version Constraint</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -101,9 +101,9 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Provided Required Arguments On Directives</a></td>
-        <td><a href="">Possible Fragment Spreads</a></td>
-        <td><a href="">Values Of Correct Type</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments On Directives</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L93">Possible Fragment Spreads</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
@@ -113,7 +113,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Unique Fragment Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -54,7 +54,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <th>Misc. Validations</th>
     </tr>
     <tr>
-        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">(Executable Definitions)</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L87">Lone Anonymous Operation</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L172">Fields on Correct Type</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names</a></td>
@@ -65,12 +65,12 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
     </tr>
     <tr>
-        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Lone Schema Definition</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">(Lone Schema Definition)</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L128">Unique Operation Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Field Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L173">Known Fragment Names</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Possible Type Extensions</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">(Possible Type Extensions)</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L429">Repeatable Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
@@ -112,7 +112,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Object Names</a></td>
+        <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -106,7 +106,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77"></a>Field Is Not Relational Type (Can't Nest Data)</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Field Is Not Relational Type (Can't Nest Data)</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -54,7 +54,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <th>Misc. Validations</th>
     </tr>
     <tr>
-        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a> <= This is implicit, because the server is code-first: it doesn't handle SDL, hence non-executable definitions are directly not supported, and the parser will already throw an error</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L87">Lone Anonymous Operation</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L172">Fields on Correct Type</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names</a></td>
@@ -65,12 +65,12 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
     </tr>
     <tr>
-        <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Lone Schema Definition</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L128">Unique Operation Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Field Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L173">Known Fragment Names</a></td>
-        <td><a href="">Possible Type Extensions</a> <= Same as above, no SDL is supported, so no "type extensions" supported</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Possible Type Extensions</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
@@ -81,7 +81,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L276">No Fragment Cycles</a></td>
-        <td><a href="">Unique Enum Value Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L262">Unique Enum Value Names</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L357">Unique Variable Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a></td>
@@ -92,7 +92,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L667">Unique Argument Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L312">No Unused Fragments</a></td>
-        <td><a href="">Unique Type Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">Variables In Allowed Position</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
@@ -103,7 +103,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L93">Possible Fragment Spreads</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77"></a>Field Is Not Relational Type (Can't Nest Data)</td>
@@ -114,7 +114,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Object Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L178">No Field Or Directive Was Found With Required Version Constraint</a></td>
@@ -125,7 +125,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
+        <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php#L95">A Directive's Behavior Can Be Modified By At Most 1 Other Directive</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -95,7 +95,7 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L1021">Values Of Correct Type</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">Variables In Allowed Position</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
@@ -106,26 +106,15 @@ GraphQL API for WordPress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
-    </tr>
-    <tr>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
-        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/HelperServices/DataloadHelperService.php#L77">Field Is Not Relational Type (Can't Nest Data)</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a> <a href="https://github.com/graphql/graphql-spec/pull/825">(Spec RFC Stage 2)</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L178">No Field Or Directive Was Found With Required Version Constraint</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -73,33 +73,33 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="">Possible Type Extensions</a> <= Same as above, no SDL is supported, so no "type extensions" supported</td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L108">Known Operation Names</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L276">No Fragment Cycles</a></td>
         <td><a href="">Unique Enum Value Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L357">Unique Variable Names</a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/OneofInputObjectTypeResolverTrait.php#L40">@oneOf Input Object Must Receive Exactly 1 Input Value</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L91">Operation Name Provided When Multiple Operations in Document</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L667">Unique Argument Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L312">No Unused Fragments</a></td>
         <td><a href="">Unique Type Names</a> <= Same as above, as the definition is via code and not SDL, this issue is impossible to happen</td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">Variables In Allowed Position</a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L127">Enum Value Must Be String</a></td>
     </tr>
     <tr>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L112">Operation Provided In Document</a></td>
         <td><a href=""></a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/215b00a97789b3b543adc2f3380d1ca8f705a2f6/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php#L26">Provided Required Arguments On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L93">Possible Fragment Spreads</a></td>
@@ -112,9 +112,20 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Object Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L261">Unique Fragment Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/InputObjectType/AbstractInputObjectTypeResolver.php#L376">Provided Required Inputs On Input Objects</a></td>
         <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -67,7 +67,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     <tr>
         <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L128">Unique Operation Names</a></td>
-        <td><a href="">Overlapping Fields Can Be Merged</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Field Names</a></td>
         <td><a href="">Known Argument Names On Directives</a></td>
         <td><a href="">Known Fragment Names</a></td>
         <td><a href="">Possible Type Extensions</a></td>
@@ -78,7 +78,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     <tr>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Scalar Leafs</a></td>
+        <td><a href=""></a></td>
         <td><a href="">Provided Required Arguments</a></td>
         <td><a href="">No Fragment Cycles</a></td>
         <td><a href="">Unique Enum Value Names</a></td>
@@ -89,7 +89,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     <tr>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Single Field Subscription</a></td>
+        <td><a href=""></a></td>
         <td><a href="">Unique Argument Names</a></td>
         <td><a href="">No Unused Fragments</a></td>
         <td><a href="">Unique Operation Types</a></td>
@@ -100,7 +100,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     <tr>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href="">Unique Input Field Names</a></td>
+        <td><a href=""></a></td>
         <td><a href="">Provided Required Arguments On Directives</a></td>
         <td><a href="">Possible Fragment Spreads</a></td>
         <td><a href="">Unique Type Names</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -26,13 +26,13 @@ GraphQL API for Wordpress provides the following features which should be taken 
         <th align="center">Batch Requests</th>
     </tr>
     <tr>
-        <td align="center">✅<br>Enabled by Default</td>
-        <td align="center">⚠️<br>Disabled by Default</td>
         <td align="center">⚠️<br>Disabled by Default</td>
         <td align="center">❌<br>No Support</td>
-        <td align="center">✅<br>Enabled by Default</td>
         <td align="center">❌<br>No Support</td>
+        <td align="center">✅<br>Enabled by Default</td>
+        <td align="center">✅<br>Enabled by Default</td>
         <td align="center">⚠️<br>Disabled by Default</td>
+        <td align="center">✅<br>Enabled by Default</td>
     </tr>
 </table>
 

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -37,7 +37,7 @@ GraphQL API for Wordpress provides the following features which should be taken 
 </table>
 
 ## Request Validations
-Total Validation Count: **XXX**
+Total Validation Count: **36**
 
 GraphQL API for Wordpress validates the following checks when a query is sent:
 

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -68,11 +68,11 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L128">Unique Operation Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php#L660">Unique Input Field Names</a></td>
-        <td><a href="">Known Argument Names On Directives</a></td>
-        <td><a href="">Known Fragment Names</a></td>
-        <td><a href="">Possible Type Extensions</a></td>
-        <td><a href="">Unique Directive Names</a></td>
-        <td><a href="">No Unused Variables</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names On Directives</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L173">Known Fragment Names</a></td>
+        <td><a href="">Possible Type Extensions</a> <= Same as above, no SDL is supported, so no "type extensions" supported</td>
+        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
         <td><a href=""></a></td>
     </tr>
     <tr>
@@ -82,7 +82,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="">Provided Required Arguments</a></td>
         <td><a href="">No Fragment Cycles</a></td>
         <td><a href="">Unique Enum Value Names</a></td>
-        <td><a href="">Unique Directives Per Location</a></td>
+        <td><a href=""></a></td>
         <td><a href="">Unique Variable Names</a></td>
         <td><a href=""></a></td>
     </tr>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -56,13 +56,13 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
     <tr>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a> <= This is implicit, because the server is code-first: it doesn't handle SDL, hence non-executable definitions are directly not supported, and the parser will already throw an error</td>
         <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L87">Lone Anonymous Operation</a></td>
-        <td><a href="">Fields on Correct Type</a></td>
-        <td><a href="">Known Argument Names</a></td>
-        <td><a href="">Fragments On Composite Types</a></td>
-        <td><a href="">Known Type Names</a></td>
-        <td><a href="">Known Directives</a></td>
-        <td><a href="">No Undefined Variables</a></td>
-        <td><a href="">Disable Introspection</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php#L172">Fields on Correct Type</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/9c05560107a1d7163f494aee742fc2cea5149a39/layers/Engine/packages/component-model/src/ExtendedSpec/Execution/ExecutableDocument.php#L111">Fragments On Composite Types</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/UnionType/AbstractUnionTypeResolver.php#L414">Known Type Names</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L248">Known Directives</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/45791105a1b850ee1b07426700c476440d43f4c0/layers/Engine/packages/graphql-parser/src/Spec/Execution/ExecutableDocument.php#L129">No Undefined Variables</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/a90db0edd3fb7dc85edc434adc3e48fb41c75356/layers/GraphQLAPIForWP/plugins/graphql-api-for-wp/docs/en/release-notes/0.9.md#exposed-the-__schema-introspection-field-in-the-acls">Disable Introspection</a></td>
     </tr>
     <tr>
         <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -71,7 +71,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/Schema/FieldQueryInterpreter.php#L465">Known Argument Names On Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L173">Known Fragment Names</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Possible Type Extensions</a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php#L429">Repeatable Directives</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/56beb22e72795e7a4ba61f33a1b75ee91e551407/layers/Engine/packages/graphql-parser/src/Spec/Parser/Ast/Document.php#L566">No Unused Variables</a></td>
         <td><a href="https://github.com/leoloso/PoP/blob/d80220235a00bdd63e27b6105ef88fd840129a92/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/Ast/ArgumentValue/DynamicVariableReference.php#L60">Dynamic Variable Has Value Exported</a></td>
     </tr>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -54,7 +54,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <th>Misc. Validations</th>
     </tr>
     <tr>
-        <td><a href="">Executable Definitions</a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/21f5820c459800946ad69b530412eded836e4f1e/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php">Executable Definitions</a> <= This is implicit, because the server is code-first: it doesn't handle SDL, hence non-executable definitions are directly not supported, and the parser will already throw an error</td>
         <td><a href="">Lone Anonymous Operation</a></td>
         <td><a href="">Fields on Correct Type</a></td>
         <td><a href="">Known Argument Names</a></td>
@@ -65,7 +65,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="">Disable Introspection</a></td>
     </tr>
     <tr>
-        <td><a href="">Lone Schema Definition</a></td>
+        <td><a href="">Lone Schema Definition</a> <= Same as above, no SDL is supported, so no "schema" can be passed in the query</td>
         <td><a href="">Unique Operation Names</a></td>
         <td><a href="">Overlapping Fields Can Be Merged</a></td>
         <td><a href="">Known Argument Names On Directives</a></td>

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -16,24 +16,24 @@ Documentation: [https://graphql-api.com/](https://graphql-api.com/)
 GraphQL API for Wordpress provides the following features which should be taken into consideration:
 
 <table>
-	<tr>
-		<th align="center">Field Suggestions</th>
-		<th align="center">Query Depth Limit</th>
-		<th align="center">Query Cost Analysis</th>
-		<th align="center">Automatic Persisted Queries</th>
-		<th align="center">Introspection</th>
-		<th align="center">Debug Mode</th>
-		<th align="center">Batch Requests</th>
-	</tr>
-	<tr>
-		<td align="center">✅<br>Enabled by Default</td>
-		<td align="center">⚠️<br>Disabled by Default</td>
-		<td align="center">⚠️<br>Disabled by Default</td>
-		<td align="center">❌<br>No Support</td>
-		<td align="center">✅<br>Enabled by Default</td>
-		<td align="center">❌<br>No Support</td>
-		<td align="center">⚠️<br>Disabled by Default</td>
-	</tr>
+    <tr>
+        <th align="center">Field Suggestions</th>
+        <th align="center">Query Depth Limit</th>
+        <th align="center">Query Cost Analysis</th>
+        <th align="center">Automatic Persisted Queries</th>
+        <th align="center">Introspection</th>
+        <th align="center">Debug Mode</th>
+        <th align="center">Batch Requests</th>
+    </tr>
+    <tr>
+        <td align="center">✅<br>Enabled by Default</td>
+        <td align="center">⚠️<br>Disabled by Default</td>
+        <td align="center">⚠️<br>Disabled by Default</td>
+        <td align="center">❌<br>No Support</td>
+        <td align="center">✅<br>Enabled by Default</td>
+        <td align="center">❌<br>No Support</td>
+        <td align="center">⚠️<br>Disabled by Default</td>
+    </tr>
 </table>
 
 ## Request Validations
@@ -42,83 +42,83 @@ Total Validation Count: **XXX**
 GraphQL API for Wordpress validates the following checks when a query is sent:
 
 <table>
-	<tr>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Documents">Document Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Operations">Operation Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Fields">Field Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Arguments">Argument Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Fragments">Fragment Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Values">Value Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Directives">Directive Validations</a></th>
-		<th><a href="https://spec.graphql.org/October2021/#sec-Validation.Variables">Variable Validations</a></th>
-		<th>Misc. Validations</th>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
-	<tr>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-		<td><a href=""></a></td>
-	</tr>
+    <tr>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Documents">Document Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Operations">Operation Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Fields">Field Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Arguments">Argument Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Fragments">Fragment Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Values">Value Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Directives">Directive Validations</a></th>
+        <th><a href="https://spec.graphql.org/October2021/#sec-Validation.Variables">Variable Validations</a></th>
+        <th>Misc. Validations</th>
+    </tr>
+    <tr>
+        <td><a href="">Executable Definitions</a></td>
+        <td><a href="">Lone Anonymous Operation</a></td>
+        <td><a href="">Fields on Correct Type</a></td>
+        <td><a href="">Known Argument Names</a></td>
+        <td><a href="">Fragments On Composite Types</a></td>
+        <td><a href="">Known Type Names</a></td>
+        <td><a href="">Known Directives</a></td>
+        <td><a href="">No Undefined Variables</a></td>
+        <td><a href="">Disable Introspection</a></td>
+    </tr>
+    <tr>
+        <td><a href="">Lone Schema Definition</a></td>
+        <td><a href="">Unique Operation Names</a></td>
+        <td><a href="">Overlapping Fields Can Be Merged</a></td>
+        <td><a href="">Known Argument Names On Directives</a></td>
+        <td><a href="">Known Fragment Names</a></td>
+        <td><a href="">Possible Type Extensions</a></td>
+        <td><a href="">Unique Directive Names</a></td>
+        <td><a href="">No Unused Variables</a></td>
+        <td><a href=""></a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Scalar Leafs</a></td>
+        <td><a href="">Provided Required Arguments</a></td>
+        <td><a href="">No Fragment Cycles</a></td>
+        <td><a href="">Unique Enum Value Names</a></td>
+        <td><a href="">Unique Directives Per Location</a></td>
+        <td><a href="">Unique Variable Names</a></td>
+        <td><a href=""></a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Single Field Subscription</a></td>
+        <td><a href="">Unique Argument Names</a></td>
+        <td><a href="">No Unused Fragments</a></td>
+        <td><a href="">Unique Operation Types</a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Variables Are Input Types</a></td>
+        <td><a href=""></a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Unique Input Field Names</a></td>
+        <td><a href="">Provided Required Arguments On Directives</a></td>
+        <td><a href="">Possible Fragment Spreads</a></td>
+        <td><a href="">Unique Type Names</a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Variables In Allowed Position</a></td>
+        <td><a href=""></a></td>
+    </tr>
+    <tr>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href="">Unique Fragment Names</a></td>
+        <td><a href="">Values Of Correct Type</a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+        <td><a href=""></a></td>
+    </tr>
 </table>
 
 ## Security Disclosure

--- a/implementations/graphql-api-for-wp.md
+++ b/implementations/graphql-api-for-wp.md
@@ -128,7 +128,7 @@ GraphQL API for Wordpress validates the following checks when a query is sent:
         <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php#L97">Enum Value is Not Valid</a></td>
         <td><a href=""></a></td>
         <td><a href=""></a></td>
-        <td><a href=""></a></td>
+        <td><a href="https://github.com/leoloso/PoP/blob/dbba064860c3df23d5731f909902243b74cb1aa1/layers/Engine/packages/graphql-parser/src/ExtendedSpec/Parser/AbstractParser.php#L95">A Directive's Behavior Can Be Modified By At Most 1 Other Directive</a></td>
     </tr>
 </table>
 


### PR DESCRIPTION
Alright, I completed the info for my server now. Please notice that I counted 37 validations, but I've listed down 40, with 3 of them between parenthesis:

- (Executable Definitions)
- (Lone Schema Definition)
- (Possible Type Extensions)

The reason is that these validations involve syntax that is valid for building the GraphQL schema using SDL, but this GraphQL server is code-first, and it does not support SDL. As such, it doesn't need to validate that `schema` is defined only once, or that any document is executable by not containing `extend`... these validations are already implicit, and the problem will never take place!

The decision is yours if to remove these entries or not. I kept them there as to say "it's implicitly taken care of".

Btw, this also makes me think that the approach of showing the implemented validations is not super helpful, because different servers can perfectly support different validations, and having less validations does not imply that the server is less secure. Then, I think that what's really more valuable would be showing **which validations from the spec are not implemented, when they should!** (or they could pose a security risk).